### PR TITLE
Fix static rss

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/generate-static-files.js && next build",
     "start": "next start"
   },
   "dependencies": {
@@ -17,11 +17,12 @@
     "@heroicons/react": "^1.0.1",
     "@mailchimp/mailchimp_marketing": "^3.0.48",
     "@tailwindcss/jit": "^0.1.18",
-    "@tailwindcss/typography": "^0.5.13",
+    "@tailwindcss/typography": "^0.5.15",
     "@tryghost/content-api": "^1.5.8",
     "autoprefixer": "^10.2.6",
     "axios": "^0.21.1",
     "better-react-mathjax": "^1.0.2",
+    "dotenv": "^16.0.3",
     "eslint-config-next": "^14.2.4",
     "fathom-client": "^3.2.0",
     "fs-extra": "^10.0.0",

--- a/pages/rss.js
+++ b/pages/rss.js
@@ -1,13 +1,30 @@
-// This page redirects to the static RSS feed
+import fs from 'fs';
+import path from 'path';
+
+// This function serves the static RSS feed
 export default function RSS() {
     return null
 }
 
 export async function getServerSideProps({ res }) {
-    // Redirect to the static RSS feed in the static directory
-    res.statusCode = 301
-    res.setHeader('Location', '/static/rss.xml')
-    res.end()
+    try {
+        // Path to the static RSS file
+        const filePath = path.join(process.cwd(), 'public', 'static', 'rss.xml');
+        
+        // Read the static file
+        const fileContent = fs.readFileSync(filePath, 'utf8');
+        
+        // Set the content type to XML
+        res.setHeader('Content-Type', 'text/xml');
+        
+        // Send the static content
+        res.write(fileContent);
+        res.end();
+    } catch (error) {
+        console.error('Error serving RSS feed:', error);
+        res.statusCode = 500;
+        res.end('Error serving RSS feed');
+    }
     
     return {
         props: {},

--- a/pages/rss.js
+++ b/pages/rss.js
@@ -1,97 +1,14 @@
-import { getPosts } from './api/ghost_data'
-
-const options = {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    weekday: 'short',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    timeZone: 'GMT',
-}
-
-const createRSS = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
-    <rss 
-        xmlns:dc="http://purl.org/dc/elements/1.1/" 
-        xmlns:content="http://purl.org/rss/1.0/modules/content/" 
-        xmlns:atom="http://www.w3.org/2005/Atom" 
-        version="2.0" 
-        xmlns:media="http://search.yahoo.com/mrss/"
-    >
-        <channel>
-            <title><![CDATA[ Who is Nnamdi? ]]></title>
-            <description>
-                <![CDATA[ Thoughts on technology, venture capital, and the economics of both ]]>
-            </description>
-            <link>https://whoisnnamdi.com</link>
-            <lastBuildDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date()) + " GMT"}</lastBuildDate>
-            <atom:link href="https://whoisnnamdi.com/rss/" rel="self" type="application/rss+xml"/>
-            ${posts
-                .map((post) => {
-                    return `<item>
-                        <title>
-                            <![CDATA[${post.title}]]>
-                        </title>
-                        <description>
-                            <![CDATA[${post.excerpt}]]>
-                        </description>
-                        <link>${`https://whoisnnamdi.com/${post.slug}/`}</link>
-                        <guid isPermaLink="false">${post.id}</guid>
-                        ${post.tags ?
-                            post
-                            .tags.map((tag) => {
-                                return `<category>
-                                        <![CDATA[ ${tag.name} ]]>
-                                    </category>
-                                `
-                            })
-                            .join("")
-                            :
-                            null
-                        }
-                        <dc:creator>
-                            <![CDATA[ Nnamdi Iregbulem ]]>
-                        </dc:creator>
-                        <pubDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date(post.published_at)) + " GMT"}</pubDate>
-                        <media:content url="${post.feature_image}" medium="image" />
-                        <content:encoded>
-                            <![CDATA[ ${post.html} ]]>
-                        </content:encoded>
-                    </item>
-                    `
-                })
-                .join("")
-            }
-        </channel>
-    </rss>
-`
-
-// This function just returns a empty component
+// This page redirects to the static RSS feed
 export default function RSS() {
     return null
 }
 
-// Use getServerSideProps to handle the request
 export async function getServerSideProps({ res }) {
-    // Set the content type to XML
-    res.setHeader('Content-Type', 'text/xml')
+    // Redirect to the static RSS feed
+    res.statusCode = 301
+    res.setHeader('Location', '/rss/feed.xml')
+    res.end()
     
-    try {
-        // Generate the RSS feed
-        const posts = await getPosts()
-        const rssContent = createRSS(posts)
-        
-        // Write the response directly
-        res.write(rssContent)
-        res.end()
-    } catch (error) {
-        console.error('Error generating RSS feed', error)
-        res.statusCode = 500
-        res.end('Error generating RSS feed')
-    }
-    
-    // Return empty props (this won't be used since we've already ended the response)
     return {
         props: {},
     }

--- a/pages/rss.js
+++ b/pages/rss.js
@@ -4,9 +4,9 @@ export default function RSS() {
 }
 
 export async function getServerSideProps({ res }) {
-    // Redirect to the static RSS feed
+    // Redirect to the static RSS feed in the static directory
     res.statusCode = 301
-    res.setHeader('Location', '/rss/feed.xml')
+    res.setHeader('Location', '/static/rss.xml')
     res.end()
     
     return {

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,51 +1,15 @@
-import { getAll } from './api/ghost_data'
-
-const others = [
-    "founders",
-    "developers",
-    "investors"
-]
-
-const createSitemap = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <url>
-        <loc>${`https://whoisnnamdi.com`}</loc>
-    </url>
-    ${posts
-        .map(({ slug }) => {
-            return `
-                <url>
-                    <loc>${`https://whoisnnamdi.com/${slug}/`}</loc>
-                </url>
-            `
-        })
-        .join("")
-    }
-    ${others
-        .map((slug) => {
-            return `
-                <url>
-                    <loc>${`https://whoisnnamdi.com/${slug}/`}</loc>
-                </url>
-            `
-        })
-        .join("")
-    }
-    </urlset>
-`
-
-export async function getServerSideProps({ res }) {
-    const postsPages = await getAll()
-
-    res.setHeader("Content-Type", "text/xml")
-    res.write(createSitemap(postsPages))
-    res.end()
-
-    return {
-        props: {}
-    }
+// This page redirects to the static sitemap
+export default function Sitemap() {
+    return null
 }
 
-export default function Sitemap() {
-    return
+export async function getServerSideProps({ res }) {
+    // Redirect to the static sitemap
+    res.statusCode = 301
+    res.setHeader('Location', '/sitemap.xml')
+    res.end()
+    
+    return {
+        props: {},
+    }
 }

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,13 +1,30 @@
-// This page redirects to the static sitemap
+import fs from 'fs';
+import path from 'path';
+
+// This function serves the static sitemap
 export default function Sitemap() {
     return null
 }
 
 export async function getServerSideProps({ res }) {
-    // Redirect to the static sitemap in the static directory
-    res.statusCode = 301
-    res.setHeader('Location', '/static/sitemap.xml')
-    res.end()
+    try {
+        // Path to the static sitemap file
+        const filePath = path.join(process.cwd(), 'public', 'static', 'sitemap.xml');
+        
+        // Read the static file
+        const fileContent = fs.readFileSync(filePath, 'utf8');
+        
+        // Set the content type to XML
+        res.setHeader('Content-Type', 'text/xml');
+        
+        // Send the static content
+        res.write(fileContent);
+        res.end();
+    } catch (error) {
+        console.error('Error serving sitemap:', error);
+        res.statusCode = 500;
+        res.end('Error serving sitemap');
+    }
     
     return {
         props: {},

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -4,9 +4,9 @@ export default function Sitemap() {
 }
 
 export async function getServerSideProps({ res }) {
-    // Redirect to the static sitemap
+    // Redirect to the static sitemap in the static directory
     res.statusCode = 301
-    res.setHeader('Location', '/sitemap.xml')
+    res.setHeader('Location', '/static/sitemap.xml')
     res.end()
     
     return {

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -30,7 +30,7 @@ const createRSS = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
             </description>
             <link>https://whoisnnamdi.com</link>
             <lastBuildDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date()) + " GMT"}</lastBuildDate>
-            <atom:link href="https://whoisnnamdi.com/static/rss.xml" rel="self" type="application/rss+xml"/>
+            <atom:link href="https://whoisnnamdi.com/rss" rel="self" type="application/rss+xml"/>
             ${posts
                 .map((post) => {
                     return `<item>

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -1,0 +1,103 @@
+// Script to generate RSS feed at build time
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { getPosts } = require('../pages/api/ghost_data');
+
+const options = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    timeZone: 'GMT',
+}
+
+const createRSS = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
+    <rss 
+        xmlns:dc="http://purl.org/dc/elements/1.1/" 
+        xmlns:content="http://purl.org/rss/1.0/modules/content/" 
+        xmlns:atom="http://www.w3.org/2005/Atom" 
+        version="2.0" 
+        xmlns:media="http://search.yahoo.com/mrss/"
+    >
+        <channel>
+            <title><![CDATA[ Who is Nnamdi? ]]></title>
+            <description>
+                <![CDATA[ Thoughts on technology, venture capital, and the economics of both ]]>
+            </description>
+            <link>https://whoisnnamdi.com</link>
+            <lastBuildDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date()) + " GMT"}</lastBuildDate>
+            <atom:link href="https://whoisnnamdi.com/rss/" rel="self" type="application/rss+xml"/>
+            ${posts
+                .map((post) => {
+                    return `<item>
+                        <title>
+                            <![CDATA[${post.title}]]>
+                        </title>
+                        <description>
+                            <![CDATA[${post.excerpt}]]>
+                        </description>
+                        <link>${`https://whoisnnamdi.com/${post.slug}/`}</link>
+                        <guid isPermaLink="false">${post.id}</guid>
+                        ${post.tags ?
+                            post
+                            .tags.map((tag) => {
+                                return `<category>
+                                        <![CDATA[ ${tag.name} ]]>
+                                    </category>
+                                `
+                            })
+                            .join("")
+                            :
+                            null
+                        }
+                        <dc:creator>
+                            <![CDATA[ Nnamdi Iregbulem ]]>
+                        </dc:creator>
+                        <pubDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date(post.published_at)) + " GMT"}</pubDate>
+                        <media:content url="${post.feature_image}" medium="image" />
+                        <content:encoded>
+                            <![CDATA[ ${post.html} ]]>
+                        </content:encoded>
+                    </item>
+                    `
+                })
+                .join("")
+            }
+        </channel>
+    </rss>
+`
+
+async function generateRSS() {
+    try {
+        console.log('Generating RSS feed...');
+        
+        // Ensure the directory exists
+        const rssDir = path.join(process.cwd(), 'public', 'rss');
+        fs.mkdirSync(rssDir, { recursive: true });
+        
+        // Generate the RSS feed
+        const posts = await getPosts();
+        const rssContent = createRSS(posts);
+        
+        // Write the file
+        const filePath = path.join(rssDir, 'feed.xml');
+        fs.writeFileSync(filePath, rssContent);
+        
+        console.log(`RSS feed generated at ${filePath}`);
+        return true;
+    } catch (error) {
+        console.error('Error generating RSS feed:', error);
+        process.exit(1);
+    }
+}
+
+// Run the function if this script is executed directly
+if (require.main === module) {
+    generateRSS();
+}
+
+module.exports = generateRSS;

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -2,7 +2,7 @@
 require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
-const { getPosts } = require('../pages/api/ghost_data');
+const { getPosts } = require('./ghost-api');
 
 const options = {
     year: 'numeric',

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -30,7 +30,7 @@ const createRSS = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
             </description>
             <link>https://whoisnnamdi.com</link>
             <lastBuildDate>${new Intl.DateTimeFormat('en-GB', options).format(new Date()) + " GMT"}</lastBuildDate>
-            <atom:link href="https://whoisnnamdi.com/rss/" rel="self" type="application/rss+xml"/>
+            <atom:link href="https://whoisnnamdi.com/static/rss.xml" rel="self" type="application/rss+xml"/>
             ${posts
                 .map((post) => {
                     return `<item>
@@ -75,16 +75,16 @@ async function generateRSS() {
     try {
         console.log('Generating RSS feed...');
         
-        // Ensure the directory exists
-        const rssDir = path.join(process.cwd(), 'public', 'rss');
-        fs.mkdirSync(rssDir, { recursive: true });
+        // Ensure the static directory exists
+        const staticDir = path.join(process.cwd(), 'public', 'static');
+        fs.mkdirSync(staticDir, { recursive: true });
         
         // Generate the RSS feed
         const posts = await getPosts();
         const rssContent = createRSS(posts);
         
         // Write the file
-        const filePath = path.join(rssDir, 'feed.xml');
+        const filePath = path.join(staticDir, 'rss.xml');
         fs.writeFileSync(filePath, rssContent);
         
         console.log(`RSS feed generated at ${filePath}`);

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,69 @@
+// Script to generate sitemap at build time
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { getAll } = require('../pages/api/ghost_data');
+
+const others = [
+    "founders",
+    "developers",
+    "investors"
+];
+
+const createSitemap = (posts) => `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>${`https://whoisnnamdi.com`}</loc>
+    </url>
+    ${posts
+        .map(({ slug }) => {
+            return `
+                <url>
+                    <loc>${`https://whoisnnamdi.com/${slug}/`}</loc>
+                </url>
+            `
+        })
+        .join("")
+    }
+    ${others
+        .map((slug) => {
+            return `
+                <url>
+                    <loc>${`https://whoisnnamdi.com/${slug}/`}</loc>
+                </url>
+            `
+        })
+        .join("")
+    }
+    </urlset>
+`;
+
+async function generateSitemap() {
+    try {
+        console.log('Generating sitemap...');
+        
+        // Ensure the public directory exists
+        const publicDir = path.join(process.cwd(), 'public');
+        
+        // Get all posts and pages
+        const postsPages = await getAll();
+        const sitemapContent = createSitemap(postsPages);
+        
+        // Write the file
+        const filePath = path.join(publicDir, 'sitemap.xml');
+        fs.writeFileSync(filePath, sitemapContent);
+        
+        console.log(`Sitemap generated at ${filePath}`);
+        return true;
+    } catch (error) {
+        console.error('Error generating sitemap:', error);
+        process.exit(1);
+    }
+}
+
+// Run the function if this script is executed directly
+if (require.main === module) {
+    generateSitemap();
+}
+
+module.exports = generateSitemap;

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -49,8 +49,10 @@ async function generateSitemap() {
         const postsPages = await getAll();
         const sitemapContent = createSitemap(postsPages);
         
-        // Write the file
-        const filePath = path.join(publicDir, 'sitemap.xml');
+        // Write the file to a different path to avoid conflict with pages/sitemap.xml.js
+        const sitemapDir = path.join(publicDir, 'static');
+        fs.mkdirSync(sitemapDir, { recursive: true });
+        const filePath = path.join(sitemapDir, 'sitemap.xml');
         fs.writeFileSync(filePath, sitemapContent);
         
         console.log(`Sitemap generated at ${filePath}`);

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,7 +2,7 @@
 require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
-const { getAll } = require('../pages/api/ghost_data');
+const { getAll } = require('./ghost-api');
 
 const others = [
     "founders",

--- a/scripts/generate-static-files.js
+++ b/scripts/generate-static-files.js
@@ -1,0 +1,24 @@
+// Unified script to generate all static files at build time
+require('dotenv').config();
+const generateRSS = require('./generate-rss');
+const generateSitemap = require('./generate-sitemap');
+
+async function generateAll() {
+    try {
+        console.log('Starting static file generation...');
+        
+        // Generate RSS feed
+        await generateRSS();
+        
+        // Generate sitemap
+        await generateSitemap();
+        
+        console.log('All static files generated successfully!');
+    } catch (error) {
+        console.error('Error generating static files:', error);
+        process.exit(1);
+    }
+}
+
+// Run the function
+generateAll();

--- a/scripts/ghost-api.js
+++ b/scripts/ghost-api.js
@@ -1,0 +1,46 @@
+// CommonJS version of ghost API for build scripts
+const GhostContentAPI = require('@tryghost/content-api');
+
+// Initialize API
+const api = new GhostContentAPI({
+    url: process.env.GHOST_API_URL,
+    key: process.env.GHOST_API_KEY,
+    version: process.env.GHOST_API_VERSION
+});
+
+async function getPosts() {
+    return await api.posts
+        .browse({
+            include: 'tags, authors',
+            limit: 'all'
+        })
+        .catch((err) => {
+            console.error(err);
+        });
+}
+
+async function getAll() {
+    const posts = await api.posts
+    .browse({
+        include: 'tags, authors',
+        limit: 'all'
+    })
+    .catch((err) => {
+        console.error(err);
+    });
+
+    const pages = await api.pages
+    .browse({
+        limit: 'all'
+    })
+    .catch((err) => {
+        console.error(err);
+    });
+
+    return posts.concat(pages);
+}
+
+module.exports = {
+    getPosts,
+    getAll
+};

--- a/scripts/test-rss.js
+++ b/scripts/test-rss.js
@@ -1,0 +1,6 @@
+// This script tests the RSS generation
+require('dotenv').config();
+const generateRSS = require('./generate-rss');
+
+console.log('Testing RSS generation...');
+generateRSS();

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,10 +188,10 @@
     postcss-selector-parser "^6.0.4"
     quick-lru "^5.1.1"
 
-"@tailwindcss/typography@^0.5.13":
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.13.tgz#cd788a4fa4d0ca2506e242d512f377b22c1f7932"
-  integrity sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==
+"@tailwindcss/typography@^0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.15.tgz#007ab9870c86082a1c76e5b3feda9392c7c8d648"
+  integrity sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==
   dependencies:
     lodash.castarray "^4.4.0"
     lodash.isplainobject "^4.0.6"


### PR DESCRIPTION
This pull request includes significant changes to the static file generation process, specifically for RSS feeds and sitemaps. The changes involve moving the generation of these files from runtime to build time, improving performance and reliability.

### Static File Generation:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R25): Updated the `build` script to include a new script `generate-static-files.js` for generating static files before building the project. Added `dotenv` as a dependency.
* [`scripts/generate-static-files.js`](diffhunk://#diff-c88bb8fc9e46a681d94d24232a276529ddcf2da23e2bc2418a2432116d4313adR1-R24): Added a new script that consolidates the generation of all static files at build time, including RSS feeds and sitemaps.

### RSS Feed:

* [`pages/rss.js`](diffhunk://#diff-15abfa578c3c1941d99d203bd260f65a8351939721ed5c01e4ad5dcef4b6dbddL1-L94): Refactored to serve a pre-generated static RSS feed instead of generating it on each request.
* [`scripts/generate-rss.js`](diffhunk://#diff-9e93383c0053f428f14939fb02c385daa3c6cd303827bd421ef69be73294d1b2R1-R103): Added a new script to generate the RSS feed at build time.

### Sitemap:

* [`pages/sitemap.xml.js`](diffhunk://#diff-6c6e294818e92038a2b11fefce01fd20d6c0402b86a11df358e97e43402a4c72L1-R31): Refactored to serve a pre-generated static sitemap instead of generating it on each request.
* [`scripts/generate-sitemap.js`](diffhunk://#diff-9dd19b2f75df1748ea75297288452b8eee5a956ffac7dcd10442d9cf4a4f6e99R1-R71): Added a new script to generate the sitemap at build time.

### API Integration:

* [`scripts/ghost-api.js`](diffhunk://#diff-9ef86650a3e4f7317f9201318200f284ae968dbe8b873db3a0d5626d5a848991R1-R46): Added a CommonJS version of the Ghost API client for use in build scripts to fetch posts and pages.