### PR TITLE
Change 'Featured Essays' section to 'Featured Essay' with single essay

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -179,7 +179,7 @@ export default function Home ({ posts, featuredPosts }) {
                 </div>
             </div>
             <h2 className="text-4xl font-bold text-gray-900 mb-4 text-center mt-8">
-                Featured Essays
+                Featured Essay
             </h2>
             <ul>
                 {posts.slice(0, 1).map((post) => (
@@ -187,7 +187,7 @@ export default function Home ({ posts, featuredPosts }) {
                         <PostPreview post={post}/>
                     </li>
                 ))}
-                {featuredPosts.slice(0, 4).map((post) => (
+                {featuredPosts.slice(0, 1).map((post) => (
                     <li key={post.id}>
                         <PostPreview post={post}/>
                     </li>

--- a/pages/index.js
+++ b/pages/index.js
@@ -182,11 +182,6 @@ export default function Home ({ posts, featuredPosts }) {
                 Featured Essay
             </h2>
             <ul>
-                {posts.slice(0, 1).map((post) => (
-                    <li key={post.id}>
-                        <PostPreview post={post}/>
-                    </li>
-                ))}
                 {featuredPosts.slice(0, 1).map((post) => (
                     <li key={post.id}>
                         <PostPreview post={post}/>


### PR DESCRIPTION
## Summary
- Changes the heading 'Featured Essays' to 'Featured Essay' (singular)
- Reduces the number of featured essays shown from four to one
- Keeps the first essay from the featured essays list

## Test plan
- Run the development server to verify the homepage shows only one featured essay
- Verify the heading is correctly changed to 'Featured Essay'
- Confirm the content layout remains visually consistent